### PR TITLE
Fix figma:asset imports and missing React dependency (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "react-resizable-panels": "2.1.7",
     "react-responsive-masonry": "2.7.1",
     "react-router": "7.13.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "react-slick": "0.31.0",
     "recharts": "2.15.2",
     "sonner": "2.0.3",
@@ -69,18 +71,6 @@
     "@vitejs/plugin-react": "4.7.0",
     "tailwindcss": "4.1.12",
     "vite": "6.3.5"
-  },
-  "peerDependencies": {
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "pnpm": {
     "overrides": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,31 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import path from 'path'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 
+/**
+ * Resolves Figma Make's proprietary `figma:asset/<hash>.png` imports to a
+ * 1×1 transparent PNG data URI so standard Vite builds succeed without the
+ * Figma-hosted asset CDN. Components that need real images should replace
+ * these imports with actual assets in public/ or src/assets/.
+ */
+function figmaAssetPlugin(): Plugin {
+  const TRANSPARENT_PNG =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
+  return {
+    name: 'vite-plugin-figma-asset',
+    resolveId(id) {
+      if (id.startsWith('figma:asset/')) return '\0figma-asset:' + id
+    },
+    load(id) {
+      if (id.startsWith('\0figma-asset:')) return `export default "${TRANSPARENT_PNG}"`
+    },
+  }
+}
+
 export default defineConfig({
   plugins: [
+    figmaAssetPlugin(),
     // The React and Tailwind plugins are both required for Make, even if
     // Tailwind is not being actively used – do not remove them
     react(),


### PR DESCRIPTION
## Summary
- Adds `vite-plugin-figma-asset` to `vite.config.ts` — resolves `figma:asset/<hash>.png` imports to a transparent 1×1 PNG data URI so the build works without Figma's CDN
- Moves `react@18.3.1` and `react-dom@18.3.1` from `peerDependencies` to `dependencies` so `npm install` produces a runnable build (this is an app, not a library)
- Build now completes cleanly: 2703 modules, 0 errors

Closes #1