### PR TITLE
Fix frontend bugs — scenario cycling, role labels, reflection persistence (#10 #11 #12 #13)

### DIFF
--- a/src/app/components/AdminDashboard.tsx
+++ b/src/app/components/AdminDashboard.tsx
@@ -136,7 +136,7 @@ function AdminDashboardInner() {
     );
   }
 
-  // Normalise score distribution key (server returns scoreDistribution, mock uses assessmentDistribution)
+  // Normalise score distribution key (server returns scoreDistribution or assessmentDistribution)
   const scoreDistribution = stats.scoreDistribution || stats.assessmentDistribution || [];
   const monthlyEnrollment = stats.monthlyEnrollment || [];
 

--- a/src/app/components/Certificate.tsx
+++ b/src/app/components/Certificate.tsx
@@ -128,7 +128,7 @@ export function Certificate() {
                   <p className="text-xs text-muted-foreground mb-1">This certifies that</p>
                   <p className="text-xl text-foreground mb-1" style={{ fontFamily: "'Playfair Display', Georgia, serif" }}>{displayName}</p>
                   <p className="text-sm text-muted-foreground mb-6">
-                    {roleLabels[displayRole] || displayRole}
+                    {ROLE_LABELS[displayRole] || displayRole}
                   </p>
 
                   <p className="text-xs text-muted-foreground mb-4">

--- a/src/app/components/ModuleDetail.tsx
+++ b/src/app/components/ModuleDetail.tsx
@@ -50,6 +50,23 @@ export function ModuleDetail() {
   const module = MODULES.find((m) => m.id === Number(moduleId));
   const { progress: userProgress, watchedVignettes, markVignetteWatched, unmarkVignetteWatched, updateModuleProgress, profile, updateProfile } = useAuth();
   const progress = userProgress.find((p) => p.moduleId === Number(moduleId));
+  // Reflections: controlled state persisted to localStorage per module+section
+  const [reflections, setReflections] = useState<Record<string, string>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(`reflections:module:${moduleId}`) || "{}");
+    } catch {
+      return {};
+    }
+  });
+
+  const handleReflectionChange = (sectionId: string, text: string) => {
+    const updated = { ...reflections, [sectionId]: text };
+    setReflections(updated);
+    try {
+      localStorage.setItem(`reflections:module:${moduleId}`, JSON.stringify(updated));
+    } catch {}
+  };
+
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
   const [selectedState, setSelectedState] = useState(profile?.selectedState || "GA");
 
@@ -362,7 +379,13 @@ export function ModuleDetail() {
                             <TTSControls text={`Guided Reflection: How does the concept of ${section.phase} apply to your professional role? Consider a recent case or situation where this approach could have changed the outcome.`} compact label="Listen" />
                           </div>
                           <p className="text-sm text-foreground/80 mb-3">How does the concept of "{section.phase}" apply to your professional role? Consider a recent case or situation where this approach could have changed the outcome.</p>
-                          <textarea className="w-full p-3 rounded-lg border border-border bg-white text-sm resize-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all" rows={3} placeholder="Write your reflection here..." />
+                          <textarea
+                            className="w-full p-3 rounded-lg border border-border bg-white text-sm resize-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                            rows={3}
+                            placeholder="Write your reflection here..."
+                            value={reflections[section.id] || ""}
+                            onChange={(e) => handleReflectionChange(section.id, e.target.value)}
+                          />
                         </div>
 
                         <div className="mt-4 flex justify-end">

--- a/src/app/components/Simulation.tsx
+++ b/src/app/components/Simulation.tsx
@@ -27,7 +27,7 @@ export function Simulation() {
   const scenarios = module?.scenarios || [];
   const { saveSimulationResult, updateModuleProgress, progress: userProgress } = useAuth();
 
-  const [scenarioIdx] = useState(0);
+  const [scenarioIdx, setScenarioIdx] = useState(0);
   const [stepIdx, setStepIdx] = useState(0);
   const [selectedChoice, setSelectedChoice] = useState<ScenarioChoice | null>(null);
   const [decisions, setDecisions] = useState<ScenarioChoice[]>([]);
@@ -124,6 +124,16 @@ export function Simulation() {
     setActiveBranchKey(null);
   };
 
+  const handleNextScenario = () => {
+    setScenarioIdx((prev) => prev + 1);
+    setStepIdx(0);
+    setSelectedChoice(null);
+    setDecisions([]);
+    setIsComplete(false);
+    setVignetteComplete(false);
+    setActiveBranchKey(null);
+  };
+
   const hasVignette = resolvedVignettes.length > 0;
   const showChoices = !hasVignette || vignetteComplete;
   const optimalCount = decisions.filter((d) => d.isOptimal).length;
@@ -203,6 +213,11 @@ export function Simulation() {
             </div>
             <div className="flex gap-3 justify-center">
               <button onClick={handleRestart} className="px-5 py-2.5 rounded-lg border border-border hover:bg-secondary text-sm flex items-center gap-2"><RefreshCw className="w-4 h-4" /> Try Again</button>
+              {scenarioIdx < scenarios.length - 1 && (
+                <button onClick={handleNextScenario} className="px-5 py-2.5 rounded-lg bg-primary text-primary-foreground text-sm hover:opacity-90 flex items-center gap-2">
+                  Next Scenario <ArrowRight className="w-4 h-4" />
+                </button>
+              )}
               <Link to={`/modules/${module.id}`} className="px-5 py-2.5 rounded-lg bg-primary text-primary-foreground text-sm hover:opacity-90">Return to Module</Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- **#10 Simulation scenario cycling**: `scenarioIdx` was read-only (`useState(0)` with no setter). Added `setScenarioIdx`, `handleNextScenario` function, and a "Next Scenario" button on the completion screen when more scenarios exist in the module
- **#11 Certificate role labels**: `roleLabels` on line 131 was an undefined variable — replaced with the imported `ROLE_LABELS`. All 9 roles including `mandated_reporter` now display correctly
- **#12 Reflection persistence**: The reflection `<textarea>` was completely uncontrolled. Added `reflections` state map with `localStorage` persistence keyed by `reflections:module:{moduleId}` — text survives page navigation and browser refresh
- **#13 AdminDashboard mock comment**: Removed stale "mock uses assessmentDistribution" comment; the error/retry path was already correct and never used mock data

Closes #10, #11, #12, #13