### PR TITLE
Tighten Content-Security-Policy headers (#6)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,15 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "X-XSS-Protection", "value": "1; mode=block" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" }
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://rchiljcopergqtozylik.supabase.co wss://rchiljcopergqtozylik.supabase.co https://api.stripe.com https://checkout.stripe.com; img-src 'self' data: blob: https://images.unsplash.com; font-src 'self' data:; frame-src https://checkout.stripe.com https://js.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(self)"
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
Adds a strict `Content-Security-Policy` header to `vercel.json`:

- `script-src 'self'` — no `unsafe-eval`, no `unsafe-inline` for scripts
- `style-src 'self' 'unsafe-inline'` — kept for emotion/MUI inline style injection (cannot be removed without significant CSS-in-JS refactoring)
- `connect-src` allowlist: Supabase project URL (HTTP + WSS), Stripe API
- `img-src` allowlist: self, data URIs, blob URLs, Unsplash CDN
- `frame-src`: Stripe checkout domains only
- `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — prevents clickjacking and injection vectors
- Updates `Permissions-Policy` to include `payment=(self)`

Closes #6